### PR TITLE
fix: resolve PCA n_components NameError

### DIFF
--- a/app.py
+++ b/app.py
@@ -206,6 +206,9 @@ def prepare_data(X, feature_names, method, selected_features, n_components, stan
     
     else:  # PCA
         # Apply PCA
+        if n_components is None:
+            n_components = 2  # Default to 2 components if not specified
+            
         if standardize:
             scaler = StandardScaler()
             X_scaled = scaler.fit_transform(X)

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,2 +1,1 @@
-[tool.poetry.dependencies]
-python = "3.11.9"
+python-3.11.9


### PR DESCRIPTION
Fixes #30

Added defensive check in prepare_data() function to handle cases where n_components is None, preventing NameError when PCA is selected.

Generated with [Claude Code](https://claude.ai/code)